### PR TITLE
Support games using UnityFramework

### DIFF
--- a/SSLKillSwitch2.plist
+++ b/SSLKillSwitch2.plist
@@ -4,6 +4,7 @@
 			"com.apple.AuthKit",
 			"com.apple.UIKit",
 			"com.apple.itunesstored",
+			"com.apple.Security"
 		);
 	};
 }


### PR DESCRIPTION
Games using Unity does not use UIKit, so add com.apple.Security to filter to support that.