### PR TITLE
Fix AFNetworking policyWithPinningMode hooks causing crash

### DIFF
--- a/SSLKillSwitch/SSLKillSwitch.m
+++ b/SSLKillSwitch/SSLKillSwitch.m
@@ -436,17 +436,17 @@ HOOKBODY({
     return old__AFSecurityPolicy_setAllowInvalidCertificates(self, _cmd, YES);
 })
 
-static BOOL (*old__AFSecurityPolicy_policyWithPinningMode)(id cls, SEL _cmd, BOOL mode);
-static BOOL new__AFSecurityPolicy_policyWithPinningMode(id cls, SEL _cmd, BOOL mode) 
+static id (*old__AFSecurityPolicy_policyWithPinningMode)(id cls, SEL _cmd, NSUInteger mode);
+static id new__AFSecurityPolicy_policyWithPinningMode(id cls, SEL _cmd, NSUInteger mode)
 HOOKBODY({
-    SSKVerboseLog("AFSecurityPolicy policyWithPinningMode: %d -> AFSSLPinningModeNone", mode);
-    return old__AFSecurityPolicy_setAllowInvalidCertificates(cls, _cmd, 0); // AFSSLPinningModeNone
+    SSKVerboseLog("AFSecurityPolicy policyWithPinningMode: %lu -> AFSSLPinningModeNone", (unsigned long)mode);
+    return old__AFSecurityPolicy_policyWithPinningMode(cls, _cmd, 0); // AFSSLPinningModeNone
 })
 
-static BOOL (*old__AFSecurityPolicy_policyWithPinningMode_withPinnedCertificates)(id cls, SEL _cmd, BOOL mode, id cert);
-static BOOL new__AFSecurityPolicy_policyWithPinningMode_withPinnedCertificates(id cls, SEL _cmd, BOOL mode, id cert) 
+static id (*old__AFSecurityPolicy_policyWithPinningMode_withPinnedCertificates)(id cls, SEL _cmd, NSUInteger mode, id cert);
+static id new__AFSecurityPolicy_policyWithPinningMode_withPinnedCertificates(id cls, SEL _cmd, NSUInteger mode, id cert)
 HOOKBODY({
-    SSKVerboseLog("AFSecurityPolicy policyWithPinningMode: %d withPinnedCertificates: %{public}@ -> AFSSLPinningModeNone", mode, cert);
+    SSKVerboseLog("AFSecurityPolicy policyWithPinningMode: %lu withPinnedCertificates: %{public}@ -> AFSSLPinningModeNone", (unsigned long)mode, cert);
     return old__AFSecurityPolicy_policyWithPinningMode_withPinnedCertificates(cls, _cmd, 0, cert); // AFSSLPinningModeNone
 })
 


### PR DESCRIPTION
  # Problem

  The policyWithPinningMode: and policyWithPinningMode:withPinnedCertificates: hooks had two bugs that caused apps using
  AFNetworking SSL pinning to crash:

  1. Wrong return type: Both are factory methods returning AFSecurityPolicy * (8-byte pointer on arm64), but the hooks
  declared the return type as BOOL (1 byte). The caller received a truncated pointer value and crashed on dereference.
  2. Wrong original function call: new__AFSecurityPolicy_policyWithPinningMode called
  old__AFSecurityPolicy_setAllowInvalidCertificates (a void-returning instance method) instead of
  old__AFSecurityPolicy_policyWithPinningMode. Copy-paste error.

  # Fix

  - Return type: BOOL → id
  - Parameter type: BOOL → NSUInteger (matching AFSSLPinningMode enum)
  - Corrected the original function pointer call in policyWithPinningMode:

  # Tested

  Verified on RootHide (iOS 16) with an app using AFSecurityPolicy policyWithPinningMode:AFSSLPinningModePublicKey
  withPinnedCertificates:. App no longer crashes and MITM proxy captures traffic successfully.